### PR TITLE
Add tests about decimal default precision and scale

### DIFF
--- a/ibis/sql/postgres/tests/test_client.py
+++ b/ibis/sql/postgres/tests/test_client.py
@@ -224,30 +224,3 @@ def test_unsupported_intervals(con):
     assert t["a"].type() == dt.Interval("Y")
     assert t["b"].type() == dt.Interval("M")
     assert t["g"].type() == dt.Interval("M")
-
-
-def test_default_numeric_precision_and_scale():
-    typespec = [
-        # name, sqlalchemy type, ibis type
-        ('n1', sa.dialects.postgresql.NUMERIC, dt.Decimal(1000, 0)),
-        ('n2', sa.dialects.postgresql.NUMERIC(5), dt.Decimal(5, 0)),
-        ('n3', sa.dialects.postgresql.NUMERIC(None, 4), dt.Decimal(1000, 4)),
-        ('n4', sa.dialects.postgresql.NUMERIC(10, 2), dt.Decimal(10, 2)),
-    ]
-
-    sqla_types = []
-    ibis_types = []
-    for name, t, ibis_type in typespec:
-        sqla_type = sa.Column(name, t, nullable=True)
-        sqla_types.append(sqla_type)
-        ibis_types.append((name, ibis_type(nullable=True)))
-
-    # Create a table with the numeric types.
-    engine = sa.create_engine('postgresql://')
-    table = sa.Table('tname', sa.MetaData(bind=engine), *sqla_types)
-
-    # Check that we can correctly recover the default precision and scale.
-    schema = alch.schema_from_table(table)
-    expected = ibis.schema(ibis_types)
-
-    assert_equal(schema, expected)

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -427,9 +427,14 @@ class MySQL(Backend, RoundHalfToEven):
         user = os.environ.get('IBIS_TEST_MYSQL_USER', 'ibis')
         password = os.environ.get('IBIS_TEST_MYSQL_PASSWORD', 'ibis')
         host = os.environ.get('IBIS_TEST_MYSQL_HOST', 'localhost')
+        port = os.environ.get('IBIS_TEST_MYSQL_PORT', 3306)
         database = os.environ.get('IBIS_TEST_MYSQL_DATABASE', 'ibis_testing')
         return ibis.mysql.connect(
-            host=host, user=user, password=password, database=database
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
         )
 
     @property


### PR DESCRIPTION
hey @ian-r-rose  I think the tests should be something like this.

it tests the default precision and scale for table creating and selecting and also for literals.
and tests will run that for postgresql and mysql. 

As it uses for now dataframe.to_sql .. it just works for sqlalchemy based backend.
I will try to move forward the `load_data` for sqlalchemy based backend .. but for now I just added a TODO comment.

feel free to accept and change it or reject that.